### PR TITLE
Add agent specification to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,78 @@
 # node-ai-agent
+
+A local code-mod agent prototype written in TypeScript.
+
+## Installation
+
+```bash
+npm install
+npm run build
+```
+
+## Usage
+
+```bash
+node dist/cli.js --repo <path> --branch <name> --task "Add GET /hello"
+```
+
+## Architecture
+
+The agent plans steps with a stubbed LLM, edits code, runs tests, and iterates until tests pass or five attempts are reached. See `src/` for implementation.
+
+To swap in a real model, replace `llmStub` with your own `LLMClient` implementation.
+
+## Specification
+
+The agent is designed to follow these phases on each run:
+
+1. **Input** – accept a plain text task along with a Git repo path and branch.
+2. **Plan / Think** – break the task into concrete steps (files to touch, tests to write, commands to run).
+3. **Edit** – modify code in place or create new files using simple‑git or shell commands.
+4. **Test loop** – for each attempt: generate/adjust tests, run `npm test`, fix failures. Stop after `MAX_ITERATIONS` (default `5`).
+5. **Output** – summarise the changes and show the unified diff.
+6. **Safety** – enforce timeouts and kill any runaway child processes.
+
+### Project layout
+
+```
+/src
+  cli.ts      // CLI entry
+  planner.ts  // converts task -> plan steps
+  llm.ts      // interface for LLM
+  llmStub.ts  // canned responses / interactive mode
+  editor.ts   // applies edits
+  tester.ts   // runs jest / mocha
+  loop.ts     // orchestration state-machine
+/tests        // self tests for the agent
+/fixtures     // sample service and stub responses
+```
+
+Implementation tips include representing each plan step as:
+
+```ts
+interface Step {
+  type: 'edit' | 'shell' | 'test';
+  description: string;
+  payload: any;
+}
+```
+
+Diffs are written to `out/diff.txt` using `git diff --color=always HEAD` and every shell command is run with a timeout of `180_000` ms.
+
+### Testing without an AI
+
+1. **Unit tests** – mock `LLMClient.complete()` with deterministic fixtures.
+2. **E2E smoke test** – run the agent on the bundled sample repo and ensure tests pass in under 30s.
+3. **Manual mode** – passing `--interactive` makes the stub prompt for each LLM response.
+
+### Codex‑2025 system prompt (excerpt)
+
+```
+You are an autonomous local code-mod agent running entirely in Node.js.
+Given a repo path, branch, and task you will:
+1. Form a plan.
+2. Execute the plan until `npm test` passes or MAX_ITERATIONS is reached.
+3. Leave the repo modified but uncommitted and print a summary + diff.
+4. Enforce MAX_ITERATIONS=5 and a per-iteration timeout of 3 min.
+5. Use the injectable `LLMClient` interface (see llmStub.ts for the stub).
+```

--- a/fixtures/responses.json
+++ b/fixtures/responses.json
@@ -1,0 +1,21 @@
+{
+  "PLAN:Add GET /hello": [
+    {
+      "type": "edit",
+      "description": "Add hello route",
+      "payload": {
+        "file": "src/app.js",
+        "append": "\napp.get('/hello', (req, res) => res.json({ message: 'hello world' }));\n"
+      }
+    },
+    {
+      "type": "edit",
+      "description": "Add test file",
+      "payload": {
+        "file": "test/hello.test.js",
+        "content": "const request = require('supertest');\nconst app = require('../src/app');\n\ntest('GET /hello', async () => {\n  await request(app).get('/hello').expect(200).expect({ message: 'hello world' });\n});\n"
+      }
+    },
+    { "type": "test", "description": "Run tests" }
+  ]
+}

--- a/fixtures/sample-service/jest.config.js
+++ b/fixtures/sample-service/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = { testEnvironment: 'node' };

--- a/fixtures/sample-service/package.json
+++ b/fixtures/sample-service/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "sample-service",
+  "version": "1.0.0",
+  "main": "src/server.js",
+  "scripts": {
+    "test": "jest",
+    "start": "node src/server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "supertest": "^6.3.3"
+  }
+}

--- a/fixtures/sample-service/src/app.js
+++ b/fixtures/sample-service/src/app.js
@@ -1,0 +1,6 @@
+const express = require('express');
+const app = express();
+
+app.get('/', (req, res) => res.json({ status: 'ok' }));
+
+module.exports = app;

--- a/fixtures/sample-service/src/server.js
+++ b/fixtures/sample-service/src/server.js
@@ -1,0 +1,3 @@
+const app = require('./app');
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`listening on ${port}`));

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "node-ai-agent",
+  "version": "1.0.0",
+  "main": "dist/cli.js",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest"
+  },
+  "dependencies": {
+    "simple-git": "^3.19.1",
+    "execa": "^7.1.1",
+    "chalk": "^4.1.2"
+  },
+  "devDependencies": {
+    "typescript": "^4.9.5",
+    "ts-jest": "^29.0.0",
+    "jest": "^29.0.0",
+    "@types/jest": "^29.0.0",
+    "@types/node": "^18.0.0"
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,22 @@
+import { runAgent } from './loop';
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts: any = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--repo') opts.repoPath = args[++i];
+    else if (arg === '--branch') opts.branch = args[++i];
+    else if (arg === '--task') opts.task = args[++i];
+  }
+  if (!opts.repoPath || !opts.branch || !opts.task) {
+    console.error('Usage: node dist/cli.js --repo <path> --branch <name> --task "<task>"');
+    process.exit(1);
+  }
+  return opts;
+}
+
+(async () => {
+  const opts = parseArgs();
+  await runAgent(opts);
+})();

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -1,0 +1,16 @@
+import fs from 'fs';
+import path from 'path';
+import { Step } from './planner';
+
+/** Apply an edit step to the repository. */
+export async function applyEdit(repoPath: string, step: Step): Promise<void> {
+  if (step.type !== 'edit') return;
+  const payload = step.payload || {};
+  const file = path.join(repoPath, payload.file);
+  if (payload.content !== undefined) {
+    await fs.promises.mkdir(path.dirname(file), { recursive: true });
+    await fs.promises.writeFile(file, payload.content);
+  } else if (payload.append !== undefined) {
+    await fs.promises.appendFile(file, payload.append);
+  }
+}

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1,0 +1,8 @@
+/** LLM client interface used by the agent. */
+export interface LLMClient {
+  /**
+   * Complete the given prompt and return a string response.
+   * @param prompt Prompt text
+   */
+  complete(prompt: string, opts?: Record<string, unknown>): Promise<string>;
+}

--- a/src/llmStub.ts
+++ b/src/llmStub.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+import { LLMClient } from './llm';
+
+/**
+ * Stubbed LLM that reads deterministic responses from fixtures/responses.json
+ * or falls back to interactive stdin.
+ */
+export class LLMStub implements LLMClient {
+  private responses: Record<string, any> = {};
+
+  constructor() {
+    const file = path.join(__dirname, '../fixtures/responses.json');
+    if (fs.existsSync(file)) {
+      this.responses = JSON.parse(fs.readFileSync(file, 'utf8'));
+    }
+  }
+
+  async complete(prompt: string): Promise<string> {
+    if (this.responses[prompt]) {
+      const data = this.responses[prompt];
+      return typeof data === 'string' ? data : JSON.stringify(data);
+    }
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const answer = await new Promise<string>((resolve) => {
+      rl.question(prompt + '\n> ', (ans) => resolve(ans));
+    });
+    rl.close();
+    return answer;
+  }
+}

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -1,0 +1,45 @@
+import fs from "fs";
+import path from "path";
+import simpleGit from 'simple-git';
+import { LLMClient } from './llm';
+import { LLMStub } from './llmStub';
+import { createPlan, Step } from './planner';
+import { applyEdit } from './editor';
+import { runTests } from './tester';
+import chalk from 'chalk';
+
+export interface RunOptions {
+  repoPath: string;
+  branch: string;
+  task: string;
+  maxIterations?: number;
+  llm?: LLMClient;
+}
+
+/**
+ * Run the agent loop on the given repository.
+ */
+export async function runAgent(options: RunOptions): Promise<void> {
+  const { repoPath, branch, task } = options;
+  const maxIterations = options.maxIterations ?? 5;
+  const llm = options.llm ?? new LLMStub();
+  const git = simpleGit(repoPath);
+  await git.checkout(branch);
+  const plan = await createPlan(task, llm);
+
+  for (let i = 0; i < Math.min(plan.length, maxIterations); i++) {
+    const step = plan[i];
+    if (step.type === 'edit') {
+      await applyEdit(repoPath, step);
+    } else if (step.type === 'test') {
+      const ok = await runTests(repoPath);
+      if (ok) break;
+    }
+  }
+
+  const diff = await git.diff(['--color=always', 'HEAD']);
+  await fs.promises.mkdir(path.join(repoPath, 'out'), { recursive: true });
+  await fs.promises.writeFile(path.join(repoPath, 'out/diff.txt'), diff);
+  console.log(chalk.green('\nDiff\n')); 
+  console.log(diff);
+}

--- a/src/planner.ts
+++ b/src/planner.ts
@@ -1,0 +1,15 @@
+import { LLMClient } from './llm';
+
+export interface Step {
+  type: 'edit' | 'test';
+  description: string;
+  payload?: any;
+}
+
+/**
+ * Create a list of steps for a task using the provided LLM client.
+ */
+export async function createPlan(task: string, llm: LLMClient): Promise<Step[]> {
+  const res = await llm.complete(`PLAN:${task}`);
+  return JSON.parse(res) as Step[];
+}

--- a/src/tester.ts
+++ b/src/tester.ts
@@ -1,0 +1,13 @@
+import { spawn } from 'child_process';
+
+/** Run npm test in the given repository. */
+export async function runTests(repoPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const proc = spawn('npm', ['test'], { cwd: repoPath, stdio: 'inherit' });
+    const timer = setTimeout(() => proc.kill('SIGTERM'), 180000);
+    proc.on('close', (code) => {
+      clearTimeout(timer);
+      resolve(code === 0);
+    });
+  });
+}

--- a/tests/agent.test.ts
+++ b/tests/agent.test.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { spawn } from 'child_process';
+import simpleGit from 'simple-git';
+import { runAgent } from '../src/loop';
+import { LLMStub } from '../src/llmStub';
+
+jest.setTimeout(60000);
+
+describe('agent e2e', () => {
+  let repoDir: string;
+
+  beforeAll(async () => {
+    repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sample-service-'));
+    fs.cpSync(path.join(__dirname, '../fixtures/sample-service'), repoDir, { recursive: true });
+    await new Promise(r => { const p = spawn('npm', ['install'], { cwd: repoDir, stdio: 'inherit' }); p.on('close', () => r(undefined)); });
+    const git = simpleGit(repoDir);
+    await git.init();
+    await git.add('.');
+    await git.commit('init');
+  });
+
+  test('adds hello route and tests pass', async () => {
+    await runAgent({ repoPath: repoDir, branch: 'master', task: 'Add GET /hello', llm: new LLMStub() });
+    const appFile = fs.readFileSync(path.join(repoDir, 'src/app.js'), 'utf8');
+    expect(appFile).toMatch('/hello');
+    const testFile = fs.readFileSync(path.join(repoDir, 'test/hello.test.js'), 'utf8');
+    expect(testFile).toMatch('GET /hello');
+    const { spawn } = await import('child_process');
+    await new Promise(r => { const p = spawn('npm', ['test'], { cwd: repoDir, stdio: 'inherit' }); p.on('close', () => r(undefined)); });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "lib": ["ES2020"],
+    "types": ["node", "jest"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- document full agent specification in README
- update tsconfig for Node typings

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847947a0718832f8ec455d8b8bb85f1